### PR TITLE
Task 61349: Remove CF target info from template (master)

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -48,7 +48,4 @@ deploy:
     $ref: deploy.json
   service-category: pipeline
   parameters:
-    prod-region: "{{region}}"
-    prod-organization: "{{organization}}"
-    prod-space: "{{space}}"
     prod-app-name: "{{sample-repo.parameters.repo_name}}"


### PR DESCRIPTION
Remove `{{region}}, {{organization}}, {{space}}` mustache templates.
The CF helper supplies initial values for these fields instead.
