### PR TITLE
Task 61349: Remove CF target from template (dedicated-no-ghe)

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -47,7 +47,4 @@ deploy:
     $ref: deploy.json
   service-category: pipeline
   parameters:
-    prod-region: "{{region}}"
-    prod-organization: "{{organization}}"
-    prod-space: prod
     prod-app-name: "{{sample-repo.parameters.repo_name}}"


### PR DESCRIPTION
Remove `{{region}}, {{organization}}, {{space}}` mustache templates.
The CF helper supplies initial values for these fields instead.
